### PR TITLE
feat(client): fetch and display poll details

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3431,64 +3431,42 @@
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
-      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
         "@types/aria-query": "^5.0.1",
         "aria-query": "5.3.0",
-        "chalk": "^4.1.0",
         "dom-accessibility-api": "^0.5.9",
         "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
         "pretty-format": "^27.0.2"
       },
       "engines": {
         "node": ">=18"
       }
     },
-    "node_modules/@testing-library/dom/node_modules/aria-query": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "dequal": "^2.0.3"
-      }
-    },
     "node_modules/@testing-library/jest-dom": {
-      "version": "6.6.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.3.tgz",
-      "integrity": "sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==",
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.4.tgz",
+      "integrity": "sha512-xDXgLjVunjHqczScfkCJ9iyjdNOVHvvCdqHSSxwM9L0l/wHkTRum67SDc020uAlCoqktJplgO2AAQeLP1wgqDQ==",
       "license": "MIT",
       "dependencies": {
         "@adobe/css-tools": "^4.4.0",
         "aria-query": "^5.0.0",
-        "chalk": "^3.0.0",
         "css.escape": "^1.5.1",
         "dom-accessibility-api": "^0.6.3",
         "lodash": "^4.17.21",
+        "picocolors": "^1.1.1",
         "redent": "^3.0.0"
       },
       "engines": {
         "node": ">=14",
         "npm": ">=6",
         "yarn": ">=1"
-      }
-    },
-    "node_modules/@testing-library/jest-dom/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
@@ -4667,12 +4645,12 @@
       }
     },
     "node_modules/aria-query": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
-      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 0.4"
+      "dependencies": {
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/array-buffer-byte-length": {
@@ -5966,12 +5944,12 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
       }
     },
     "node_modules/cookie-signature": {
@@ -7501,6 +7479,15 @@
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
       }
     },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/eslint-plugin-react": {
       "version": "7.37.5",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
@@ -7951,6 +7938,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -14027,15 +14023,6 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
-      }
-    },
-    "node_modules/react-router/node_modules/cookie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
-      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/react-scripts": {

--- a/client/src/components/PollDetail.tsx
+++ b/client/src/components/PollDetail.tsx
@@ -1,7 +1,62 @@
+import { useState, useEffect } from "react";
+import { useParams } from "react-router-dom";
+import { PollDetailData } from "../types"; // <-- IMPORT FROM THE NEW TYPES FILE
+
 const PollDetail = () => {
+  // useParams hook from react-router-dom to get URL parameters
+  const { id } = useParams<{ id: string }>();
+
+  // State for the poll data, loading status, and errors
+  const [poll, setPoll] = useState<PollDetailData | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchPollDetail = async () => {
+      try {
+        const response = await fetch(
+          `http://localhost:3001/api/v1/polls/${id}`
+        );
+        if (!response.ok) {
+          const errorData = await response.json();
+          throw new Error(errorData.error || "Poll could not be fetched!");
+        }
+        const data: PollDetailData = await response.json();
+        setPoll(data);
+      } catch (error: any) {
+        setError(error.message);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (id) {
+      fetchPollDetail();
+    }
+  }, [id]); // The effect re-runs if the 'id' from the URL changes
+
+  if (loading) {
+    return <div>Loading poll details...</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error}</div>;
+  }
+
+  if (!poll) {
+    return <div>Poll not found.</div>;
+  }
+
   return (
     <div>
-      <h2>Poll Details</h2>
+      <h2>{poll.question}</h2>
+      <ul>
+        {poll.options.map((option) => (
+          <li key={option.id}>
+            {option.option_text} - (Votes: {option.votes})
+          </li>
+        ))}
+      </ul>
     </div>
   );
 };

--- a/client/src/components/PollList.tsx
+++ b/client/src/components/PollList.tsx
@@ -1,16 +1,10 @@
 import { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
-
-// Define a TypeScript interface for the shape of our poll data
-// This should match the data sent by our backend API
-interface Poll {
-  id: number;
-  question: string;
-}
+import { PollListData } from "../types"; // <-- IMPORT FROM THE NEW TYPES FILE
 
 const PollList = () => {
   // State to store the list of polls fetched from the API
-  const [polls, setPolls] = useState<Poll[]>([]);
+  const [polls, setPolls] = useState<PollListData[]>([]);
   // State to handle the loading status while we fetch data
   const [loading, setLoading] = useState<boolean>(true);
   // State to store any potential error messages
@@ -18,27 +12,24 @@ const PollList = () => {
 
   // useEffect hook to perform the data fetch when the component mounts
   useEffect(() => {
-    // Define an async function inside the effect to fetch data
     const fetchPolls = async () => {
       try {
-        // The URL of our backend endpoint
         const response = await fetch("http://localhost:3001/api/v1/polls");
         if (!response.ok) {
           throw new Error("Data could not be fetched!");
         }
-        const data: Poll[] = await response.json();
-        setPolls(data); // Update the state with the fetched polls
+        const data: PollListData[] = await response.json();
+        setPolls(data);
       } catch (error: any) {
-        setError(error.message); // Store any error message in state
+        setError(error.message);
       } finally {
-        setLoading(false); // Set loading to false once the fetch is complete
+        setLoading(false);
       }
     };
 
     fetchPolls();
-  }, []); // The empty dependency array [] means this effect runs only once when the component mounts
+  }, []); // The empty dependency array [] means this effect runs only once
 
-  // Conditional rendering based on the state
   if (loading) {
     return <div>Loading polls...</div>;
   }

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -1,0 +1,22 @@
+/**
+ * This file contains the TypeScript type definitions for the data structures
+ * used throughout the client-side application.
+ */
+
+// Interface for a single option within a poll
+export interface Option {
+  id: number;
+  option_text: string;
+  votes: number;
+}
+
+export interface PollDetailData {
+  id: number;
+  question: string;
+  options: Option[];
+}
+
+export interface PollListData {
+  id: number;
+  question: string;
+}

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -20,7 +16,5 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
This commit implements the data fetching and rendering logic for the PollDetail component.

- Uses the `useParams` hook to get the poll ID from the URL.
- Fetches data for a single poll from the `/api/v1/polls/:id` endpoint.
- Implements conditional rendering for loading, error, and success states.
- Renders the poll question and a list of its options with their current vote counts.
- Centralizes frontend type definitions into a new `src/types.ts` file.

Closes #13 